### PR TITLE
bump: update upload-artifact v3

### DIFF
--- a/actions/build-docker/action.yml
+++ b/actions/build-docker/action.yml
@@ -8,7 +8,7 @@ runs:
         npx gulp docker-build
         docker save -o ${{steps.package-name.outputs.packageName}}.tar ${{steps.package-name.outputs.imageName}} 
         
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: docker
         path: ${{steps.package-name.outputs.packageName}}.tar


### PR DESCRIPTION
actions/upload-artifact@v2 is outdated now:

https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/