### PR TITLE
bump: actions update from v3 to v4

### DIFF
--- a/actions/build-docker/action.yml
+++ b/actions/build-docker/action.yml
@@ -8,7 +8,7 @@ runs:
         npx gulp docker-build
         docker save -o ${{steps.package-name.outputs.packageName}}.tar ${{steps.package-name.outputs.imageName}} 
         
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: docker
         path: ${{steps.package-name.outputs.packageName}}.tar

--- a/actions/build-npm/action.yml
+++ b/actions/build-npm/action.yml
@@ -18,7 +18,7 @@ runs:
         npm pack --pack-destination .builds
         npm pack -ws --pack-destination .builds || echo No workspaces
           
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: npm
         path: |

--- a/actions/load-artifacts-npm/action.yml
+++ b/actions/load-artifacts-npm/action.yml
@@ -6,7 +6,7 @@ runs:
     - id: detect-package-metadata
       uses: DevExpress/testcafe-build-system/actions/detect-package-metadata@main
     
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: npm
 

--- a/actions/read-matrix-status/action.yml
+++ b/actions/read-matrix-status/action.yml
@@ -8,7 +8,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: matrix-status
 

--- a/actions/save-matrix-status/action.yml
+++ b/actions/save-matrix-status/action.yml
@@ -11,7 +11,7 @@ runs:
       shell: bash
       run: echo ${{ job.status }} > matrix-status-${{ inputs.job-id }}.txt
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: matrix-status
         path: matrix-status-${{ inputs.job-id }}.txt


### PR DESCRIPTION
v3 was deprecated:

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/